### PR TITLE
use protocol used for loading page

### DIFF
--- a/Control.OSMGeocoder.js
+++ b/Control.OSMGeocoder.js
@@ -171,7 +171,8 @@ L.Control.OSMGeocoder = L.Control.extend({
 			}
 		}
 
-		var url = " http://nominatim.openstreetmap.org/search" + L.Util.getParamString(params),
+                var protocol = location.protocol;
+		var url = protocol + "//nominatim.openstreetmap.org/search" + L.Util.getParamString(params),
 		script = document.createElement("script");
 
 


### PR DESCRIPTION
Nominatim supports HTTPS. So it would make sense to use HTTPS instead of HTTP when the plugin is used on a page which is served over HTTPS.
